### PR TITLE
Debug: Add extensive logging and simplify shader for black screen issue

### DIFF
--- a/src/render-worker.js
+++ b/src/render-worker.js
@@ -122,9 +122,12 @@ self.onmessage = function(event) {
 
             // Initialize matrices
             const aspectRatio = canvas.width / canvas.height;
+            console.log("Render Worker (Init): aspectRatio:", aspectRatio);
             mat4.perspective(projectionMatrix, Math.PI / 4, aspectRatio, 0.1, 100.0);
+            console.log("Render Worker (Init): projectionMatrix:", projectionMatrix);
             mat4.lookAt(viewMatrix, [0, 1, 3], [0, 0, 0], [0, 1, 0]); // Camera at (0,1,3), looking at origin, up is Y
-            mat4.identity(modelMatrix);
+            console.log("Render Worker (Init): viewMatrix:", viewMatrix);
+            mat4.identity(modelMatrix); // modelMatrix is initialized here but logged per-frame
             
             self.postMessage({ status: "Render worker: Cube assets and matrices initialized." });
 
@@ -149,11 +152,18 @@ self.onmessage = function(event) {
         // Update Model Matrix
         mat4.identity(modelMatrix);
         mat4.rotateY(modelMatrix, modelMatrix, cubeRotationY);
+        console.log("Render Worker (renderScene): modelMatrix:", modelMatrix);
         // Example translation: mat4.translate(modelMatrix, modelMatrix, [0, 0, -2]); // Moves cube 2 units away
 
         // Calculate MVP Matrix
         mat4.multiply(mvpMatrix, viewMatrix, modelMatrix);      // mvpMatrix = viewMatrix * modelMatrix
         mat4.multiply(mvpMatrix, projectionMatrix, mvpMatrix); // mvpMatrix = projectionMatrix * mvpMatrix (which is view * model)
+        
+        console.log("Render Worker: Calling render with mvpMatrix:", mvpMatrix);
+        console.log("Render Worker: shaderProgram:", shaderProgram);
+        console.log("Render Worker: attributeLocations:", attributeLocations);
+        console.log("Render Worker: uniformLocations:", uniformLocations);
+        console.log("Render Worker: cubeBuffers:", cubeBuffers);
         
         render(gl, shaderProgram, attributeLocations, uniformLocations, cubeBuffers, mvpMatrix);
         // self.postMessage({ status: "Scene rendered" }); // Optional

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -13,9 +13,8 @@ export const vertexShaderSource = `
 
 export const fragmentShaderSource = `
     precision mediump float;
-    varying vec3 v_color;
     void main() {
-        gl_FragColor = vec4(v_color, 1.0);
+        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0); /* Solid Red */
     }
 `;
 
@@ -143,6 +142,7 @@ function render(gl, program, attributeLocations, uniformLocations, buffers, mvpM
     // gl.enable(gl.DEPTH_TEST); // Set in initWebGL
     // gl.depthFunc(gl.LEQUAL); // Set in initWebGL
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    // gl.disable(gl.DEPTH_TEST);
 
     // 2. Set Viewport
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);


### PR DESCRIPTION
I've made several changes to help diagnose why the spinning cube results in a black screen with no errors.

- `src/render-worker.js`:
    - I've added logging for the initial `aspectRatio`, `projectionMatrix`, and `viewMatrix` in the `init` handler.
    - I'm now logging the per-frame `modelMatrix` in the `renderScene` handler.
    - I've also added logging for all parameters (`mvpMatrix`, shader program, locations, buffers) passed to the `render()` function.
- `src/renderer.js`:
    - I've simplified the `fragmentShaderSource` to output a constant solid red color. This will help us determine if geometry is being rasterized at all.
    - I've added a commented-out line `// gl.disable(gl.DEPTH_TEST);` to allow easy testing of depth test issues.

These changes are intended to provide detailed console output that can be used to trace data flow and identify potential problems in the rendering pipeline.