### PR TITLE
Fix: Resolve duplicate export error in renderer.js

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -190,4 +190,4 @@ function render(gl, program, attributeLocations, uniformLocations, buffers, mvpM
     gl.drawElements(gl.TRIANGLES, vertexCount, gl.UNSIGNED_SHORT, 0);
 }
 
-export { initWebGL, render, vertexShaderSource, fragmentShaderSource, compileShader, createProgram };
+export { initWebGL, render };


### PR DESCRIPTION
Removes `vertexShaderSource`, `fragmentShaderSource`, `compileShader`, and `createProgram` from the named export block at the end of `src/renderer.js`.

These items were already being exported at their definition sites (e.g., `export const vertexShaderSource = ...;` or `export function compileShader(...) {}`), causing a 'Duplicate export' syntax error. This change ensures they are exported only once.